### PR TITLE
Reverse chronological order

### DIFF
--- a/calrules/exchange.py
+++ b/calrules/exchange.py
@@ -30,7 +30,7 @@ class Exchange:
 
     def items(self):
         items = []
-        for item in self.account.inbox.all():
+        for item in self.account.inbox.all().order_by("-datetime_received"):
             if not isinstance(item, MeetingRequest) and not isinstance(item, MeetingCancellation):
                 continue
 


### PR DESCRIPTION
I have a large, messy inbox with a lot of calendar cruft.

I'd prefer to operate on the newer messages first.  Functionally,
there's no change if you let the operation go through to completion.

This should probably be changed to a configurable later including:
- Time span to search
- Ordering
- other things that exchangelib can do

For now, this suits my purposes, but given the lack of functional change I'd not be upset were this rejected.