### PR TITLE
Add config for number of days to search

### DIFF
--- a/calrules/config.py
+++ b/calrules/config.py
@@ -8,6 +8,7 @@ exchange:
   server: str()
   email: str()
   ca_cert: str(required=False)
+  days_back: int(required=False)
 
 rules: list(include('rule'))
 


### PR DESCRIPTION
New config item `days_back` allows implmentation of filter to only search backwards by _n_ days -- this will likely be handy for large mailboxes where the rule processing is done regularly and time to completion is long (like mine!)

I've not (yet) considered ways to search for different period lengths (minutes, hours, months etc.) but days seems a happy trade off for an initial pass.

I'm not fussed on the variable name -- alternative suggestions welcome.