### PR TITLE
Break on mark

### DIFF
--- a/calrules/__main__.py
+++ b/calrules/__main__.py
@@ -44,6 +44,7 @@ def main():
 
             if match and i.action is not None:
                 i.mark(r.response, r.message)
+                break
 
     for i in items:
         if i.action is Response.NOOP:

--- a/calrules/__main__.py
+++ b/calrules/__main__.py
@@ -44,6 +44,7 @@ def main():
 
             if match and i.action is not None:
                 i.mark(r.response, r.message)
+                LOG.debug(f"Marking {i.subject} with response: {r.message}.  Further processing of this item ceased.")
                 break
 
     for i in items:


### PR DESCRIPTION
This change exits the rule processing loop after the first match is found.

---

At the moment, unlike procmail, the rules are all executed sequentially regardless of flags etc.

There is an edge case where an item might be matched by more than one rule.  In this circumstance, the last rule in the list "wins".

It logically makes more sense to me for the first match to "win" -- as in the example docs currently, I have a DELETE rule for cancellations as the first rule; I could move this to last, but top down ordering makes more sense to me.

There are also runtime benefits as you only need to keep attempting matches until the first one hits (as opposed to processing every rule each time).

