### PR TITLE
Add conditional to delete op

### DIFF
--- a/calrules/item.py
+++ b/calrules/item.py
@@ -90,10 +90,11 @@ class Item:
 
     def delete(self):
         try:
-            self.item.account.inbox.get(
-                id=self.item.associated_calendar_item_id.id,
-                changekey=self.item.associated_calendar_item_id.changekey
-            ).delete()
+            if self.item.associated_calendar_item_id:
+                self.item.account.inbox.get(
+                    id=self.item.associated_calendar_item_id.id,
+                    changekey=self.item.associated_calendar_item_id.changekey
+                ).delete()
 
             self.item.delete(affected_task_occurrences='AllOccurrences')
         except Exception as e:


### PR DESCRIPTION
Not all items have an associated calendar items.  This results in an exception if they're missing (and the item doesn't get deleted).

This adds a basic conditional to avoid the error.